### PR TITLE
update validate-arguments-of-public-methods#aspire-hosting-redis

### DIFF
--- a/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
+++ b/src/Aspire.Hosting.Redis/RedisBuilderExtensions.cs
@@ -401,7 +401,7 @@ public static class RedisBuilderExtensions
     public static IResourceBuilder<RedisResource> WithDataBindMount(this IResourceBuilder<RedisResource> builder, string source, bool isReadOnly = false)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrEmpty(source);
 
         builder.WithBindMount(source, "/data", isReadOnly);
         if (!isReadOnly)
@@ -464,7 +464,7 @@ public static class RedisBuilderExtensions
     public static IResourceBuilder<RedisInsightResource> WithDataBindMount(this IResourceBuilder<RedisInsightResource> builder, string source)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrEmpty(source);
 
         return builder.WithBindMount(source, "/data");
     }

--- a/tests/Aspire.Hosting.Redis.Tests/RedisPublicApiTests.cs
+++ b/tests/Aspire.Hosting.Redis.Tests/RedisPublicApiTests.cs
@@ -9,10 +9,8 @@ namespace Aspire.Hosting.Redis.Tests;
 
 public class RedisPublicApiTests
 {
-    #region RedisBuilderExtensions
-
     [Fact]
-    public void AddRedisContainerShouldThrowWhenBuilderIsNull()
+    public void AddRedisShouldThrowWhenBuilderIsNull()
     {
         IDistributedApplicationBuilder builder = null!;
         const string name = "Redis";
@@ -23,15 +21,19 @@ public class RedisPublicApiTests
         Assert.Equal(nameof(builder), exception.ParamName);
     }
 
-    [Fact]
-    public void AddRedisContainerShouldThrowWhenNameIsNull()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddRedisShouldThrowWhenNameIsNullOrEmpty(bool isNull)
     {
-        IDistributedApplicationBuilder builder = new DistributedApplicationBuilder([]);
-        string name = null!;
+        var builder = TestDistributedApplicationBuilder.Create();
+        var name = isNull ? null! : string.Empty;
 
         var action = () => builder.AddRedis(name);
 
-        var exception = Assert.Throws<ArgumentNullException>(action);
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
         Assert.Equal(nameof(name), exception.ParamName);
     }
 
@@ -47,7 +49,7 @@ public class RedisPublicApiTests
     }
 
     [Fact]
-    public void WithRedisInsightResourceShouldThrowWhenBuilderIsNull()
+    public void WithRedisInsightShouldThrowWhenBuilderIsNull()
     {
         IResourceBuilder<RedisResource> builder = null!;
 
@@ -70,7 +72,7 @@ public class RedisPublicApiTests
     }
 
     [Fact]
-    public void RedisInsightResourceWithHostPortShouldThrowWhenBuilderIsNull()
+    public void RedisInsightWithHostPortShouldThrowWhenBuilderIsNull()
     {
         IResourceBuilder<RedisInsightResource> builder = null!;
         const int port = 777;
@@ -104,16 +106,20 @@ public class RedisPublicApiTests
         Assert.Equal(nameof(builder), exception.ParamName);
     }
 
-    [Fact]
-    public void WithDataBindMountShouldThrowWhenNameIsNull()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WithDataBindMountShouldThrowWhenNameIsNullOrEmpty(bool isNull)
     {
         var builder = TestDistributedApplicationBuilder.Create();
         var redis = builder.AddRedis("Redis");
-        string source = null!;
+        var source = isNull ? null! : string.Empty;
 
         var action = () => redis.WithDataBindMount(source);
 
-        var exception = Assert.Throws<ArgumentNullException>(action);
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
         Assert.Equal(nameof(source), exception.ParamName);
     }
 
@@ -128,35 +134,90 @@ public class RedisPublicApiTests
         Assert.Equal(nameof(builder), exception.ParamName);
     }
 
-    #endregion
+    [Fact]
+    public void RedisInsightWithDataVolumeShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<RedisInsightResource> builder = null!;
 
-    #region RedisCommanderResource
+        var action = () => builder.WithDataVolume();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
 
     [Fact]
-    public void CtorRedisCommanderResourceShouldThrowWhenNameIsNull()
+    public void RedisInsightWithDataBindMountShouldThrowWhenBuilderIsNull()
     {
-        string name = null!;
+        IResourceBuilder<RedisInsightResource> builder = null!;
+        const string source = "/data";
+
+        var action = () => builder.WithDataBindMount(source);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void RedisInsightWithDataBindMountShouldThrowWhenNameIsNullOrEmpty(bool isNull)
+    {
+        var builder = TestDistributedApplicationBuilder.Create();
+        IResourceBuilder<RedisInsightResource>? redisInsightBuilder = null;
+        var redis = builder.AddRedis("Redis").WithRedisInsight(resource => { redisInsightBuilder = resource; });
+        var source = isNull ? null! : string.Empty;
+
+        Assert.NotNull(redisInsightBuilder);
+        var action = () => redisInsightBuilder.WithDataBindMount(source);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(source), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CtorRedisCommanderResourceShouldThrowWhenNameIsNullOrEmpty(bool isNull)
+    {
+        var name = isNull ? null! : string.Empty;
 
         var action = () => new RedisCommanderResource(name);
 
-        var exception = Assert.Throws<ArgumentNullException>(action);
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
         Assert.Equal(nameof(name), exception.ParamName);
     }
 
-    #endregion
-
-    #region RedisResource
-
-    [Fact]
-    public void CtorRedisResourceShouldThrowWhenNameIsNull()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CtorRedisInsightResourceShouldThrowWhenNameIsNullOrEmpty(bool isNull)
     {
-        string name = null!;
+        var name = isNull ? null! : string.Empty;
+
+        var action = () => new RedisInsightResource(name);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(name), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CtorRedisResourceShouldThrowWhenNameIsNullOrEmpty(bool isNull)
+    {
+        var name = isNull ? null! : string.Empty;
 
         var action = () => new RedisResource(name);
 
-        var exception = Assert.Throws<ArgumentNullException>(action);
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
         Assert.Equal(nameof(name), exception.ParamName);
     }
-
-    #endregion
 }


### PR DESCRIPTION
Initial issues [#2649](https://github.com/dotnet/aspire/issues/2649)
Issues [#5047](https://github.com/dotnet/aspire/issues/5047)
[message](https://github.com/dotnet/aspire/issues/5047#issuecomment-2278838761)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No

Added public API test coverage for:
- [x] Aspire.Hosting.Redis

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5402)