### PR TITLE
update validate-arguments-of-public-methods#aspire-hosting-my-sql

### DIFF
--- a/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
+++ b/src/Aspire.Hosting.MySql/MySqlBuilderExtensions.cs
@@ -29,7 +29,7 @@ public static class MySqlBuilderExtensions
     public static IResourceBuilder<MySqlServerResource> AddMySql(this IDistributedApplicationBuilder builder, [ResourceName] string name, IResourceBuilder<ParameterResource>? password = null, int? port = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(name);
+        ArgumentException.ThrowIfNullOrEmpty(name);
 
         var passwordParameter = password?.Resource ?? ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(builder, $"{name}-password");
 
@@ -71,7 +71,7 @@ public static class MySqlBuilderExtensions
     public static IResourceBuilder<MySqlDatabaseResource> AddDatabase(this IResourceBuilder<MySqlServerResource> builder, [ResourceName] string name, string? databaseName = null)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(name);
+        ArgumentException.ThrowIfNullOrEmpty(name);
 
         // Use the resource name as the database name if it's not provided
         databaseName ??= name;
@@ -216,7 +216,7 @@ public static class MySqlBuilderExtensions
     public static IResourceBuilder<MySqlServerResource> WithDataBindMount(this IResourceBuilder<MySqlServerResource> builder, string source, bool isReadOnly = false)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrEmpty(source);
 
         return builder.WithBindMount(source, "/var/lib/mysql", isReadOnly);
     }
@@ -231,7 +231,7 @@ public static class MySqlBuilderExtensions
     public static IResourceBuilder<MySqlServerResource> WithInitBindMount(this IResourceBuilder<MySqlServerResource> builder, string source, bool isReadOnly = true)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrEmpty(source);
 
         return builder.WithBindMount(source, "/docker-entrypoint-initdb.d", isReadOnly);
     }

--- a/src/Aspire.Hosting.MySql/MySqlDatabaseResource.cs
+++ b/src/Aspire.Hosting.MySql/MySqlDatabaseResource.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
 namespace Aspire.Hosting.ApplicationModel;
 
 /// <summary>
@@ -9,12 +12,13 @@ namespace Aspire.Hosting.ApplicationModel;
 /// <param name="name">The name of the resource.</param>
 /// <param name="databaseName">The database name.</param>
 /// <param name="parent">The MySQL parent resource associated with this database.</param>
-public class MySqlDatabaseResource(string name, string databaseName, MySqlServerResource parent) : Resource(name), IResourceWithParent<MySqlServerResource>, IResourceWithConnectionString
+public class MySqlDatabaseResource(string name, string databaseName, MySqlServerResource parent)
+    : Resource(name), IResourceWithParent<MySqlServerResource>, IResourceWithConnectionString
 {
     /// <summary>
     /// Gets the parent MySQL container resource.
     /// </summary>
-    public MySqlServerResource Parent { get; } = parent;
+    public MySqlServerResource Parent { get; } = parent ?? throw new ArgumentNullException(nameof(parent));
 
     /// <summary>
     /// Gets the connection string expression for the MySQL database.
@@ -25,5 +29,11 @@ public class MySqlDatabaseResource(string name, string databaseName, MySqlServer
     /// <summary>
     /// Gets the database name.
     /// </summary>
-    public string DatabaseName { get; } = databaseName;
+    public string DatabaseName { get; } = ThrowIfNullOrEmpty(databaseName);
+
+    private static string ThrowIfNullOrEmpty([NotNull] string? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(argument, paramName);
+        return argument;
+    }
 }

--- a/tests/Aspire.Hosting.MySql.Tests/MySqlPublicApiTests.cs
+++ b/tests/Aspire.Hosting.MySql.Tests/MySqlPublicApiTests.cs
@@ -10,10 +10,10 @@ namespace Aspire.Hosting.MySql.Tests;
 public class MySqlPublicApiTests
 {
     [Fact]
-    public void AddMySqlContainerShouldThrowWhenBuilderIsNull()
+    public void AddMySqlShouldThrowWhenBuilderIsNull()
     {
         IDistributedApplicationBuilder builder = null!;
-        string name = "MySql";
+        const string name = "MySql";
 
         var action = () => builder.AddMySql(name);
 
@@ -21,16 +21,74 @@ public class MySqlPublicApiTests
         Assert.Equal(nameof(builder), exception.ParamName);
     }
 
-    [Fact]
-    public void AddMySqlContainerShouldThrowWhenNameIsNull()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddMySqlShouldThrowWhenNameIsNullOrEmpty(bool isNull)
     {
-        var builder = DistributedApplication.CreateBuilder([]);
-        string name = null!;
+        var builder = TestDistributedApplicationBuilder.Create();
+        var name = isNull ? null! : string.Empty;
 
         var action = () => builder.AddMySql(name);
 
-        var exception = Assert.Throws<ArgumentNullException>(action);
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
         Assert.Equal(nameof(name), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddDatabaseShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<MySqlServerResource> builder = null!;
+        const string name = "db";
+
+        var action = () => builder.AddDatabase(name);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddDatabaseShouldThrowWhenNameIsNullOrEmpty(bool isNull)
+    {
+        var builder = TestDistributedApplicationBuilder.Create()
+            .AddMySql("MySql");
+        var name = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddDatabase(name);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(name), exception.ParamName);
+    }
+
+    [Fact]
+    public void WithPhpMyAdminShouldThrowWhenBuilderIsNull()
+    {
+        IResourceBuilder<MySqlServerResource> builder = null!;
+
+        var action = () => builder.WithPhpMyAdmin();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WithHostPortShouldThrowWhenBuilderIsNull(bool includePort)
+    {
+        IResourceBuilder<PhpMyAdminContainerResource> builder = null!;
+        int? port = includePort ? null : 6033;
+
+        var action = () => builder.WithHostPort(port);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
     }
 
     [Fact]
@@ -48,7 +106,7 @@ public class MySqlPublicApiTests
     public void WithDataBindMountShouldThrowWhenBuilderIsNull()
     {
         IResourceBuilder<MySqlServerResource> builder = null!;
-        string source = "/MySql/data";
+        const string source = "/MySql/data";
 
         var action = () => builder.WithDataBindMount(source);
 
@@ -56,16 +114,20 @@ public class MySqlPublicApiTests
         Assert.Equal(nameof(builder), exception.ParamName);
     }
 
-    [Fact]
-    public void WithDataBindMountShouldThrowWhenSourceIsNull()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WithDataBindMountShouldThrowWhenSourceIsNullOrEmpty(bool isNull)
     {
-        var builder = TestDistributedApplicationBuilder.Create();
-        var mySql = builder.AddMySql("MySql");
-        string source = null!;
+        var builder = TestDistributedApplicationBuilder.Create()
+            .AddMySql("MySql");
+        var source = isNull ? null! : string.Empty;
 
-        var action = () => mySql.WithDataBindMount(source);
+        var action = () => builder.WithDataBindMount(source);
 
-        var exception = Assert.Throws<ArgumentNullException>(action);
+        var exception = isNull
+           ? Assert.Throws<ArgumentNullException>(action)
+           : Assert.Throws<ArgumentException>(action);
         Assert.Equal(nameof(source), exception.ParamName);
     }
 
@@ -73,7 +135,7 @@ public class MySqlPublicApiTests
     public void WithInitBindMountShouldThrowWhenBuilderIsNull()
     {
         IResourceBuilder<MySqlServerResource> builder = null!;
-        string source = "/MySql/init.sql";
+        const string source = "/MySql/init.sql";
 
         var action = () => builder.WithInitBindMount(source);
 
@@ -81,76 +143,94 @@ public class MySqlPublicApiTests
         Assert.Equal(nameof(builder), exception.ParamName);
     }
 
-    [Fact]
-    public void WithInitBindMountShouldThrowWhenSourceIsNull()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WithInitBindMountShouldThrowWhenSourceIsNullOrEmpty(bool isNull)
     {
-        var builder = TestDistributedApplicationBuilder.Create();
-        var mySql = builder.AddMySql("MySql");
-        string source = null!;
+        var builder = TestDistributedApplicationBuilder.Create()
+            .AddMySql("MySql");
+        var source = isNull ? null! : string.Empty;
 
-        var action = () => mySql.WithInitBindMount(source);
+        var action = () => builder.WithInitBindMount(source);
 
-        var exception = Assert.Throws<ArgumentNullException>(action);
+        var exception = isNull
+           ? Assert.Throws<ArgumentNullException>(action)
+           : Assert.Throws<ArgumentException>(action);
         Assert.Equal(nameof(source), exception.ParamName);
     }
 
-    [Fact]
-    public void AddDatabaseShouldThrowWhenBuilderIsNull()
-    {
-        IResourceBuilder<MySqlServerResource> builder = null!;
-        var name = "db";
-
-        var action = () => builder.AddDatabase(name);
-
-        var exception = Assert.Throws<ArgumentNullException>(action);
-        Assert.Equal(nameof(builder), exception.ParamName);
-    }
-
-    [Fact]
-    public void AddDatabaseShouldThrowWhenNameIsNull()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CtorMySqlDatabaseResourceShouldThrowWhenNameIsNullOrEmpty(bool isNull)
     {
         var builder = TestDistributedApplicationBuilder.Create();
-        var mySql = builder.AddMySql("MySql");
-        string name = null!;
+        var name = isNull ? null! : string.Empty;
+        const string databaseName = "db";
+        const string passwordName = "password";
+        var password = ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(builder, passwordName, special: false);
+        const string parentName = "parent";
+        var parent = new MySqlServerResource(parentName, password);
 
-        var action = () => mySql.AddDatabase(name);
+        var action = () => new MySqlDatabaseResource(name, databaseName, parent);
 
-        var exception = Assert.Throws<ArgumentNullException>(action);
+        var exception = isNull
+           ? Assert.Throws<ArgumentNullException>(action)
+           : Assert.Throws<ArgumentException>(action);
         Assert.Equal(nameof(name), exception.ParamName);
     }
 
-    [Fact]
-    public void WithPhpMyAdminShouldThrowWhenBuilderIsNull()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CtorMySqlDatabaseResourceShouldThrowWhenDatabaseNameIsNullOrEmpty(bool isNull)
     {
-        IResourceBuilder<MySqlServerResource> builder = null!;
+        var builder = TestDistributedApplicationBuilder.Create();
+        const string name = "MySql";
+        var databaseName = isNull ? null! : string.Empty;
+        const string passwordName = "password";
+        var password = ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(builder, passwordName, special: false);
+        const string parentName = "parent";
+        var parent = new MySqlServerResource(parentName, password);
 
-        var action = () => builder.WithPhpMyAdmin();
+        var action = () => new MySqlDatabaseResource(name, databaseName, parent);
+
+        var exception = isNull
+           ? Assert.Throws<ArgumentNullException>(action)
+           : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(databaseName), exception.ParamName);
+    }
+
+    [Fact]
+    public void CtorMySqlDatabaseResourceShouldThrowWhenParentIsNull()
+    {
+        var builder = TestDistributedApplicationBuilder.Create();
+        const string name = "MySql";
+        const string databaseName = "db";
+        MySqlServerResource parent = null!;
+
+        var action = () => new MySqlDatabaseResource(name, databaseName, parent);
 
         var exception = Assert.Throws<ArgumentNullException>(action);
-        Assert.Equal(nameof(builder), exception.ParamName);
-    }
-    [Fact]
-    public void WithHostPortShouldThrowWhenBuilderIsNull()
-    {
-        IResourceBuilder<PhpMyAdminContainerResource> builder = null!;
-
-        var action = () => builder.WithHostPort(6033);
-
-        var exception = Assert.Throws<ArgumentNullException>(action);
-        Assert.Equal(nameof(builder), exception.ParamName);
+        Assert.Equal(nameof(parent), exception.ParamName);
     }
 
-    [Fact]
-    public void CtorMySqlServerResourceShouldThrowWhenNameIsNull()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CtorMySqlServerResourceShouldThrowWhenNameIsNullOrEmpty(bool isNull)
     {
-        var distributedApplicationBuilder = DistributedApplication.CreateBuilder([]);
-        string name = null!;
-
-        var password = ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(distributedApplicationBuilder, "password", special: false);
+        var builder = TestDistributedApplicationBuilder.Create();
+        var name = isNull ? null! : string.Empty;
+        const string passwordName = "password";
+        var password = ParameterResourceBuilderExtensions.CreateDefaultPasswordParameter(builder, passwordName, special: false);
 
         var action = () => new MySqlServerResource(name, password);
 
-        var exception = Assert.Throws<ArgumentNullException>(action);
+        var exception = isNull
+           ? Assert.Throws<ArgumentNullException>(action)
+           : Assert.Throws<ArgumentException>(action);
         Assert.Equal(nameof(name), exception.ParamName);
     }
 
@@ -164,5 +244,20 @@ public class MySqlPublicApiTests
 
         var exception = Assert.Throws<ArgumentNullException>(action);
         Assert.Equal(nameof(password), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CtorPhpMyAdminContainerResourceShouldThrowWhenNameIsNullOrEmpty(bool isNull)
+    {
+        var name = isNull ? null! : string.Empty;
+
+        var action = () => new PhpMyAdminContainerResource(name);
+
+        var exception = isNull
+           ? Assert.Throws<ArgumentNullException>(action)
+           : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(name), exception.ParamName);
     }
 }


### PR DESCRIPTION
Initial issues [#2649](https://github.com/dotnet/aspire/issues/2649)
Issues [#5047](https://github.com/dotnet/aspire/issues/5047)
[message](https://github.com/dotnet/aspire/issues/5047#issuecomment-2278838761)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No

Added public API test coverage for:
- [x] Aspire.Hosting.MySql

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5402)