### PR TITLE
update validate-arguments-of-public-methods#aspire-azure-data-tables

### DIFF
--- a/src/Components/Aspire.Azure.Data.Tables/AspireTablesExtensions.cs
+++ b/src/Components/Aspire.Azure.Data.Tables/AspireTablesExtensions.cs
@@ -37,6 +37,9 @@ public static class AspireTablesExtensions
         Action<AzureDataTablesSettings>? configureSettings = null,
         Action<IAzureClientBuilder<TableServiceClient, TableClientOptions>>? configureClientBuilder = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(connectionName);
+
         new TableServiceComponent().AddClient(builder, DefaultConfigSectionName, configureSettings, configureClientBuilder, connectionName, serviceKey: null);
     }
 
@@ -56,6 +59,7 @@ public static class AspireTablesExtensions
         Action<AzureDataTablesSettings>? configureSettings = null,
         Action<IAzureClientBuilder<TableServiceClient, TableClientOptions>>? configureClientBuilder = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(name);
 
         new TableServiceComponent().AddClient(builder, DefaultConfigSectionName, configureSettings, configureClientBuilder, connectionName: name, serviceKey: name);

--- a/tests/Aspire.Azure.Data.Tables.Tests/AspireAzureDataTablesPublicApiTests.cs
+++ b/tests/Aspire.Azure.Data.Tables.Tests/AspireAzureDataTablesPublicApiTests.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Aspire.Azure.Data.Tables.Tests;
+
+public class AspireAzureDataTablesPublicApiTests
+{
+    [Fact]
+    public void AddAzureTableClientShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string connectionName = "tables";
+
+        var action = () => builder.AddAzureTableClient(connectionName);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddAzureTableClientShouldThrowWhenConnectionNameIsNullOrEmpty(bool isNull)
+    {
+        var builder = new HostApplicationBuilder();
+        var connectionName = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddAzureTableClient(connectionName);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(connectionName), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddKeyedAzureTableClientShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string name = "tables";
+
+        var action = () => builder.AddKeyedAzureTableClient(name);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddKeyedAzureTableClientShouldThrowWhenNameIsNullOrEmpty(bool isNull)
+    {
+        var builder = new HostApplicationBuilder();
+        var name = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddKeyedAzureTableClient(name);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(name), exception.ParamName);
+    }
+}


### PR DESCRIPTION
Initial issues [#2649](https://github.com/dotnet/aspire/issues/2649)
Issues [#5047](https://github.com/dotnet/aspire/issues/5047)
[message](https://github.com/dotnet/aspire/issues/5047#issuecomment-2278838761)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No

Added public API test coverage for:
- [x] Aspire.Azure.Data.Tables

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5402)