### PR TITLE
update validate-arguments-of-public-methods#aspire-azure-messaging-event-hubs

### DIFF
--- a/src/Components/Aspire.Azure.Messaging.EventHubs/AspireEventHubsExtensions.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/AspireEventHubsExtensions.cs
@@ -33,6 +33,9 @@ public static class AspireEventHubsExtensions
         Action<AzureMessagingEventHubsProcessorSettings>? configureSettings = null,
         Action<IAzureClientBuilder<EventProcessorClient, EventProcessorClientOptions>>? configureClientBuilder = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(connectionName);
+
         new EventProcessorClientComponent()
             .AddClient(builder, DefaultConfigSectionName + nameof(EventProcessorClient),
                 configureSettings, configureClientBuilder, connectionName, serviceKey: null);
@@ -53,6 +56,7 @@ public static class AspireEventHubsExtensions
         Action<AzureMessagingEventHubsProcessorSettings>? configureSettings = null,
         Action<IAzureClientBuilder<EventProcessorClient, EventProcessorClientOptions>>? configureClientBuilder = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(name);
 
         new EventProcessorClientComponent()
@@ -75,6 +79,9 @@ public static class AspireEventHubsExtensions
         Action<AzureMessagingEventHubsPartitionReceiverSettings>? configureSettings = null,
         Action<IAzureClientBuilder<PartitionReceiver, PartitionReceiverOptions>>? configureClientBuilder = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(connectionName);
+
         new PartitionReceiverClientComponent()
             .AddClient(builder, DefaultConfigSectionName + nameof(PartitionReceiver),
                 configureSettings, configureClientBuilder, connectionName, serviceKey: null);
@@ -95,6 +102,7 @@ public static class AspireEventHubsExtensions
         Action<AzureMessagingEventHubsPartitionReceiverSettings>? configureSettings = null,
         Action<IAzureClientBuilder<PartitionReceiver, PartitionReceiverOptions>>? configureClientBuilder = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(name);
 
         new PartitionReceiverClientComponent()
@@ -117,6 +125,9 @@ public static class AspireEventHubsExtensions
         Action<AzureMessagingEventHubsProducerSettings>? configureSettings = null,
         Action<IAzureClientBuilder<EventHubProducerClient, EventHubProducerClientOptions>>? configureClientBuilder = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(connectionName);
+
         new EventHubProducerClientComponent()
             .AddClient(builder, DefaultConfigSectionName + nameof(EventHubProducerClient),
                 configureSettings, configureClientBuilder, connectionName, serviceKey: null);
@@ -137,6 +148,7 @@ public static class AspireEventHubsExtensions
         Action<AzureMessagingEventHubsProducerSettings>? configureSettings = null,
         Action<IAzureClientBuilder<EventHubProducerClient, EventHubProducerClientOptions>>? configureClientBuilder = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(name);
 
         new EventHubProducerClientComponent()
@@ -160,6 +172,9 @@ public static class AspireEventHubsExtensions
         Action<IAzureClientBuilder<EventHubBufferedProducerClient, EventHubBufferedProducerClientOptions>>?
             configureClientBuilder = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(connectionName);
+
         new EventHubBufferedProducerClientComponent()
             .AddClient(builder, DefaultConfigSectionName + nameof(EventHubBufferedProducerClient), configureSettings,
                 configureClientBuilder, connectionName, serviceKey: null);
@@ -181,6 +196,7 @@ public static class AspireEventHubsExtensions
         Action<AzureMessagingEventHubsBufferedProducerSettings>? configureSettings = null,
         Action<IAzureClientBuilder<EventHubBufferedProducerClient, EventHubBufferedProducerClientOptions>>? configureClientBuilder = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(name);
 
         new EventHubBufferedProducerClientComponent()
@@ -203,6 +219,9 @@ public static class AspireEventHubsExtensions
         Action<AzureMessagingEventHubsConsumerSettings>? configureSettings = null,
         Action<IAzureClientBuilder<EventHubConsumerClient, EventHubConsumerClientOptions>>? configureClientBuilder = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(connectionName);
+
         new EventHubConsumerClientComponent()
             .AddClient(builder, DefaultConfigSectionName + nameof(EventHubConsumerClient),
                 configureSettings, configureClientBuilder, connectionName, serviceKey: null);
@@ -224,6 +243,7 @@ public static class AspireEventHubsExtensions
         Action<AzureMessagingEventHubsConsumerSettings>? configureSettings = null,
         Action<IAzureClientBuilder<EventHubConsumerClient, EventHubConsumerClientOptions>>? configureClientBuilder = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(name);
 
         new EventHubConsumerClientComponent()

--- a/src/Components/Aspire.Azure.Messaging.EventHubs/PartitionReceiverClientComponent.cs
+++ b/src/Components/Aspire.Azure.Messaging.EventHubs/PartitionReceiverClientComponent.cs
@@ -25,6 +25,7 @@ internal sealed class PartitionReceiverClientComponent()
     {
         config.Bind(settings);
     }
+
     protected override IAzureClientBuilder<PartitionReceiver, PartitionReceiverOptions> AddClient(
         AzureClientFactoryBuilder azureFactoryBuilder, AzureMessagingEventHubsPartitionReceiverSettings settings,
         string connectionName, string configurationSectionName)

--- a/tests/Aspire.Azure.AI.OpenAI.Tests/AIOpenAIPublicApiTests.cs
+++ b/tests/Aspire.Azure.AI.OpenAI.Tests/AIOpenAIPublicApiTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Aspire.Azure.AI.OpenAI.Tests;
 
-public class AzureAIOpenAIPublicApiTests
+public class AIOpenAIPublicApiTests
 {
     [Fact]
     public void CtorAspireAzureOpenAIClientBuilderShouldThrowWhenBuilderIsNull()

--- a/tests/Aspire.Azure.Data.Tables.Tests/DataTablesPublicApiTests.cs
+++ b/tests/Aspire.Azure.Data.Tables.Tests/DataTablesPublicApiTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Aspire.Azure.Data.Tables.Tests;
 
-public class AspireAzureDataTablesPublicApiTests
+public class DataTablesPublicApiTests
 {
     [Fact]
     public void AddAzureTableClientShouldThrowWhenBuilderIsNull()

--- a/tests/Aspire.Azure.Messaging.EventHubs.Tests/MessagingEventHubsPublicApiTests.cs
+++ b/tests/Aspire.Azure.Messaging.EventHubs.Tests/MessagingEventHubsPublicApiTests.cs
@@ -1,0 +1,290 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Aspire.Azure.Messaging.EventHubs.Tests;
+
+public class MessagingEventHubsPublicApiTests
+{
+    [Fact]
+    public void AddAzureEventProcessorClientShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string connectionName = "EventHubs";
+
+        var action = () => builder.AddAzureEventProcessorClient(connectionName);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddAzureEventProcessorClientShouldThrowWhenConnectionNameIsNullOrEmpty(bool isNull)
+    {
+        IHostApplicationBuilder builder = new HostApplicationBuilder();
+        var connectionName = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddAzureEventProcessorClient(connectionName);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(connectionName), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddKeyedAzureEventProcessorClientShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string name = "EventHubs";
+
+        var action = () => builder.AddKeyedAzureEventProcessorClient(name);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddKeyedAzureEventProcessorClientShouldThrowWhenNameIsNullOrEmpty(bool isNull)
+    {
+        IHostApplicationBuilder builder = new HostApplicationBuilder();
+        var name = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddKeyedAzureEventProcessorClient(name);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(name), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddAzurePartitionReceiverClientShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string connectionName = "EventHubs";
+
+        var action = () => builder.AddAzurePartitionReceiverClient(connectionName);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddAzurePartitionReceiverClientShouldThrowWhenConnectionNameIsNullOrEmpty(bool isNull)
+    {
+        IHostApplicationBuilder builder = new HostApplicationBuilder();
+        var connectionName = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddAzurePartitionReceiverClient(connectionName);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(connectionName), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddKeyedAzurePartitionReceiverClientShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string name = "EventHubs";
+
+        var action = () => builder.AddKeyedAzurePartitionReceiverClient(name);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddKeyedAzurePartitionReceiverClientShouldThrowWhenNameIsNullOrEmpty(bool isNull)
+    {
+        IHostApplicationBuilder builder = new HostApplicationBuilder();
+        var name = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddKeyedAzurePartitionReceiverClient(name);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(name), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddAzureEventHubProducerClientShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string connectionName = "EventHubs";
+
+        var action = () => builder.AddAzureEventHubProducerClient(connectionName);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddAzureEventHubProducerClientShouldThrowWhenConnectionNameIsNullOrEmpty(bool isNull)
+    {
+        IHostApplicationBuilder builder = new HostApplicationBuilder();
+        var connectionName = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddAzureEventHubProducerClient(connectionName);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(connectionName), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddKeyedAzureEventHubProducerClientShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string name = "EventHubs";
+
+        var action = () => builder.AddKeyedAzureEventHubProducerClient(name);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddKeyedAzureEventHubProducerClientShouldThrowWhenNameIsNullOrEmpty(bool isNull)
+    {
+        IHostApplicationBuilder builder = new HostApplicationBuilder();
+        var name = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddKeyedAzureEventHubProducerClient(name);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(name), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddAzureEventHubBufferedProducerClientShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string connectionName = "EventHubs";
+
+        var action = () => builder.AddAzureEventHubBufferedProducerClient(connectionName);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddAzureEventHubBufferedProducerClientShouldThrowWhenConnectionNameIsNullOrEmpty(bool isNull)
+    {
+        IHostApplicationBuilder builder = new HostApplicationBuilder();
+        var connectionName = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddAzureEventHubBufferedProducerClient(connectionName);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(connectionName), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddKeyedAzureEventHubBufferedProducerClientShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string name = "EventHubs";
+
+        var action = () => builder.AddKeyedAzureEventHubBufferedProducerClient(name);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddKeyedAzureEventHubBufferedProducerClientShouldThrowWhenNameIsNullOrEmpty(bool isNull)
+    {
+        IHostApplicationBuilder builder = new HostApplicationBuilder();
+        var name = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddKeyedAzureEventHubBufferedProducerClient(name);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(name), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddAzureEventHubConsumerClientShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string connectionName = "EventHubs";
+
+        var action = () => builder.AddAzureEventHubConsumerClient(connectionName);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddAzureEventHubConsumerClientShouldThrowWhenConnectionNameIsNullOrEmpty(bool isNull)
+    {
+        IHostApplicationBuilder builder = new HostApplicationBuilder();
+        var connectionName = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddAzureEventHubConsumerClient(connectionName);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(connectionName), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddKeyedAzureEventHubConsumerClientShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string name = "EventHubs";
+
+        var action = () => builder.AddKeyedAzureEventHubConsumerClient(name);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddKeyedAzureEventHubConsumerClientShouldThrowWhenNameIsNullOrEmpty(bool isNull)
+    {
+        IHostApplicationBuilder builder = new HostApplicationBuilder();
+        var name = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddKeyedAzureEventHubConsumerClient(name);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(name), exception.ParamName);
+    }
+}


### PR DESCRIPTION
Initial issues [#2649](https://github.com/dotnet/aspire/issues/2649)
Issues [#5047](https://github.com/dotnet/aspire/issues/5047)
[message](https://github.com/dotnet/aspire/issues/5047#issuecomment-2278838761)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No

Added public API test coverage for:
- [x] Aspire.Azure.Messaging.Event.Hubs

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5402)