### PR TITLE
update validate-arguments-of-public-methods#aspire-azure-messaging-service-bus

### DIFF
--- a/src/Components/Aspire.Azure.Messaging.ServiceBus/AspireServiceBusExtensions.cs
+++ b/src/Components/Aspire.Azure.Messaging.ServiceBus/AspireServiceBusExtensions.cs
@@ -37,6 +37,9 @@ public static class AspireServiceBusExtensions
         Action<AzureMessagingServiceBusSettings>? configureSettings = null,
         Action<IAzureClientBuilder<ServiceBusClient, ServiceBusClientOptions>>? configureClientBuilder = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(connectionName);
+
         new MessageBusComponent().AddClient(builder, DefaultConfigSectionName, configureSettings, configureClientBuilder, connectionName, serviceKey: null);
     }
 
@@ -55,6 +58,7 @@ public static class AspireServiceBusExtensions
         Action<AzureMessagingServiceBusSettings>? configureSettings = null,
         Action<IAzureClientBuilder<ServiceBusClient, ServiceBusClientOptions>>? configureClientBuilder = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(name);
 
         new MessageBusComponent().AddClient(builder, DefaultConfigSectionName, configureSettings, configureClientBuilder, connectionName: name, serviceKey: name);

--- a/tests/Aspire.Azure.Messaging.ServiceBus.Tests/MessagingServiceBusPublicApiTests.cs
+++ b/tests/Aspire.Azure.Messaging.ServiceBus.Tests/MessagingServiceBusPublicApiTests.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Aspire.Azure.Messaging.ServiceBus.Tests;
+
+public class MessagingServiceBusPublicApiTests
+{
+    [Fact]
+    public void AddAzureServiceBusClientShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string connectionName = "ServiceBus";
+
+        var action = () => builder.AddAzureServiceBusClient(connectionName);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddAzureServiceBusClientShouldThrowWhenConnectionNameIsNullOrEmpty(bool isNull)
+    {
+        IHostApplicationBuilder builder = new HostApplicationBuilder();
+        var connectionName = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddAzureServiceBusClient(connectionName);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(connectionName), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddKeyedAzureServiceBusClientShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string name = "ServiceBus";
+
+        var action = () => builder.AddKeyedAzureServiceBusClient(name);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddKeyedAzureServiceBusClientShouldThrowWhenNameIsNullOrEmpty(bool isNull)
+    {
+        IHostApplicationBuilder builder = new HostApplicationBuilder();
+        var name = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddKeyedAzureServiceBusClient(name);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(name), exception.ParamName);
+    }
+}


### PR DESCRIPTION
Initial issues [#2649](https://github.com/dotnet/aspire/issues/2649)
Issues [#5047](https://github.com/dotnet/aspire/issues/5047)
[message](https://github.com/dotnet/aspire/issues/5047#issuecomment-2278838761)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No

Added public API test coverage for:
- [x] Aspire.Azure.Messaging.ServiceBus

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5402)