### PR TITLE
update validate-arguments-of-public-methods#aspire-azure-messaging-web-pub-sub

### DIFF
--- a/src/Components/Aspire.Azure.Messaging.WebPubSub/AspireWebPubSubExtensions.cs
+++ b/src/Components/Aspire.Azure.Messaging.WebPubSub/AspireWebPubSubExtensions.cs
@@ -36,6 +36,9 @@ public static class AspireWebPubSubExtensions
         Action<AzureMessagingWebPubSubSettings>? configureSettings = null,
         Action<IAzureClientBuilder<WebPubSubServiceClient, WebPubSubServiceClientOptions>>? configureClientBuilder = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(connectionName);
+
         new WebPubSubComponent().AddClient(builder, DefaultConfigSectionName, configureSettings, configureClientBuilder, connectionName, serviceKey: null);
     }
 
@@ -56,6 +59,7 @@ public static class AspireWebPubSubExtensions
         Action<AzureMessagingWebPubSubSettings>? configureSettings = null,
         Action<IAzureClientBuilder<WebPubSubServiceClient, WebPubSubServiceClientOptions>>? configureClientBuilder = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
         ArgumentException.ThrowIfNullOrEmpty(connectionName);
         ArgumentException.ThrowIfNullOrEmpty(serviceKey);
 

--- a/tests/Aspire.Azure.Messaging.WebPubSub.Tests/MessagingWebPubSubPublicApiTests.cs
+++ b/tests/Aspire.Azure.Messaging.WebPubSub.Tests/MessagingWebPubSubPublicApiTests.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Aspire.Azure.Messaging.WebPubSub.Tests;
+
+public class MessagingWebPubSubPublicApiTests
+{
+    [Fact]
+    public void AddAzureWebPubSubServiceClientShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string connectionName = "wps";
+
+        var action = () => builder.AddAzureWebPubSubServiceClient(connectionName);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddAzureWebPubSubServiceClientShouldThrowWhenConnectionNameIsNullOrEmpty(bool isNull)
+    {
+        IHostApplicationBuilder builder = new HostApplicationBuilder();
+        var connectionName = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddAzureWebPubSubServiceClient(connectionName);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(connectionName), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddKeyedAzureWebPubSubServiceClientShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string connectionName = "wps";
+        const string serviceKey = "wps";
+
+        var action = () => builder.AddKeyedAzureWebPubSubServiceClient(connectionName, serviceKey);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddKeyedAzureWebPubSubServiceClientShouldThrowWhenConnectionNameIsNullOrEmpty(bool isNull)
+    {
+        IHostApplicationBuilder builder = new HostApplicationBuilder();
+        var connectionName = isNull ? null! : string.Empty;
+        const string serviceKey = "wps";
+
+        var action = () => builder.AddKeyedAzureWebPubSubServiceClient(connectionName, serviceKey);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(connectionName), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddKeyedAzureWebPubSubServiceClientShouldThrowWhenServiceKeyIsNullOrEmpty(bool isNull)
+    {
+        IHostApplicationBuilder builder = new HostApplicationBuilder();
+        const string connectionName = "wps";
+        var serviceKey = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddKeyedAzureWebPubSubServiceClient(connectionName, serviceKey);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(serviceKey), exception.ParamName);
+    }
+}


### PR DESCRIPTION
Initial issues [#2649](https://github.com/dotnet/aspire/issues/2649)
Issues [#5047](https://github.com/dotnet/aspire/issues/5047)
[message](https://github.com/dotnet/aspire/issues/5047#issuecomment-2278838761)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No

Added public API test coverage for:
- [x] Aspire.Azure.Messaging.WebPubSub

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5402)