### PR TITLE
update validate-arguments-of-public-methods#aspire-microsoft-azure-cosmos

### DIFF
--- a/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosExtensions.cs
+++ b/src/Components/Aspire.Microsoft.Azure.Cosmos/AspireMicrosoftAzureCosmosExtensions.cs
@@ -52,6 +52,8 @@ public static class AspireMicrosoftAzureCosmosExtensions
         Action<MicrosoftAzureCosmosSettings>? configureSettings = null,
         Action<CosmosClientOptions>? configureClientOptions = null)
     {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
         AddAzureCosmosClient(builder, configureSettings, configureClientOptions, connectionName: name, serviceKey: name);
     }
 
@@ -63,6 +65,7 @@ public static class AspireMicrosoftAzureCosmosExtensions
         string? serviceKey)
     {
         ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(connectionName);
 
         var settings = new MicrosoftAzureCosmosSettings();
         var configSection = builder.Configuration.GetSection(DefaultConfigSectionName);

--- a/tests/Aspire.Microsoft.Azure.Cosmos.Tests/MicrosoftAzureCosmosPublicApiTests.cs
+++ b/tests/Aspire.Microsoft.Azure.Cosmos.Tests/MicrosoftAzureCosmosPublicApiTests.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Aspire.Microsoft.Azure.Cosmos.Tests;
+
+public class MicrosoftAzureCosmosPublicApiTests
+{
+    [Fact]
+    public void AddAzureCosmosClientShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string connectionName = "cosmos";
+
+        var action = () => builder.AddAzureCosmosClient(connectionName);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddAzureCosmosClientShouldThrowWhenConnectionNameIsNullOrEmpty(bool isNull)
+    {
+        IHostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
+        var connectionName = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddAzureCosmosClient(connectionName);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(connectionName), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddKeyedAzureCosmosClientShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string name = "cosmos";
+
+        var action = () => builder.AddKeyedAzureCosmosClient(name);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddKeyedAzureCosmosClientShouldThrowWhenConnectionNameIsNullOrEmpty(bool isNull)
+    {
+        IHostApplicationBuilder builder = Host.CreateEmptyApplicationBuilder(null);
+        var name = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddKeyedAzureCosmosClient(name);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(name), exception.ParamName);
+    }
+}


### PR DESCRIPTION
Initial issues [#2649](https://github.com/dotnet/aspire/issues/2649)
Issues [#5047](https://github.com/dotnet/aspire/issues/5047)
[message](https://github.com/dotnet/aspire/issues/5047#issuecomment-2278838761)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No

Added public API test coverage for:
- [x] Aspire.Microsoft.Azure.Cosmos

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5402)