### PR TITLE
update validate-arguments-of-public-methods#aspire-microsoft-entity-framework-core-cosmos

### DIFF
--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/AspireAzureEFCoreCosmosExtensions.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.Cosmos/AspireAzureEFCoreCosmosExtensions.cs
@@ -43,6 +43,8 @@ public static class AspireAzureEFCoreCosmosExtensions
         Action<DbContextOptionsBuilder>? configureDbContextOptions = null) where TContext : DbContext
     {
         ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(connectionName);
+        ArgumentException.ThrowIfNullOrEmpty(databaseName);
 
         builder.EnsureDbContextNotRegistered<TContext>();
 
@@ -122,7 +124,8 @@ public static class AspireAzureEFCoreCosmosExtensions
     /// <exception cref="InvalidOperationException">Thrown when mandatory <see cref="DbContext"/> is not registered in DI.</exception>
     public static void EnrichCosmosDbContext<[DynamicallyAccessedMembers(RequiredByEF)] TContext>(
             this IHostApplicationBuilder builder,
-            Action<EntityFrameworkCoreCosmosSettings>? configureSettings = null) where TContext : DbContext
+            Action<EntityFrameworkCoreCosmosSettings>? configureSettings = null)
+        where TContext : DbContext
     {
         ArgumentNullException.ThrowIfNull(builder);
 

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/MicrosoftEntityFrameworkCoreCosmosPublicApiTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests/MicrosoftEntityFrameworkCoreCosmosPublicApiTests.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Aspire.Microsoft.EntityFrameworkCore.Cosmos.Tests;
+
+public class MicrosoftEntityFrameworkCoreCosmosPublicApiTests
+{
+    [Fact]
+    public void AddCosmosDbContextShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string connectionName = "cosmos";
+        const string databaseName = "cosmosdb";
+
+        var action = () => builder.AddCosmosDbContext<DbContext>(connectionName, databaseName);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddCosmosDbContextShouldThrowWhenConnectionNameIsNullOrEmpty(bool isNull)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var connectionName = isNull ? null! : string.Empty;
+        const string databaseName = "cosmosdb";
+
+        var action = () => builder.AddCosmosDbContext<DbContext>(connectionName, databaseName);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(connectionName), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddCosmosDbContextShouldThrowWhenDatabaseNameIsNullOrEmpty(bool isNull)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        const string connectionName = "cosmos";
+        var databaseName = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddCosmosDbContext<DbContext>(connectionName, databaseName);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(databaseName), exception.ParamName);
+    }
+
+    [Fact]
+    public void EnrichCosmosDbContextShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+
+        var action = () => builder.EnrichCosmosDbContext<DbContext>();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+}


### PR DESCRIPTION
Initial issues [#2649](https://github.com/dotnet/aspire/issues/2649)
Issues [#5047](https://github.com/dotnet/aspire/issues/5047)
[message](https://github.com/dotnet/aspire/issues/5047#issuecomment-2278838761)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No

Added public API test coverage for:
- [x] Aspire.Microsoft.EentityFrameworkCore.Cosmos

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5402)