### PR TITLE
update validate-arguments-of-public-methods#aspire-microsoft-entity-framework-core-sql-server

### DIFF
--- a/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/AspireSqlServerEFCoreSqlClientExtensions.cs
+++ b/src/Components/Aspire.Microsoft.EntityFrameworkCore.SqlServer/AspireSqlServerEFCoreSqlClientExtensions.cs
@@ -41,6 +41,7 @@ public static class AspireSqlServerEFCoreSqlClientExtensions
         Action<DbContextOptionsBuilder>? configureDbContextOptions = null) where TContext : DbContext
     {
         ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(connectionName);
 
         builder.EnsureDbContextNotRegistered<TContext>();
 

--- a/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/MicrosoftEntityFrameworkCoreSqlServerPublicApiTests.cs
+++ b/tests/Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests/MicrosoftEntityFrameworkCoreSqlServerPublicApiTests.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Aspire.Microsoft.EntityFrameworkCore.SqlServer.Tests;
+
+public class MicrosoftEntityFrameworkCoreSqlServerPublicApiTests
+{
+    [Fact]
+    public void AddSqlServerDbContextShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string connectionName = "sqldb";
+
+        var action = () => builder.AddSqlServerDbContext<DbContext>(connectionName);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddSqlServerDbContextShouldThrowWhenConnectionNameIsNullOrEmpty(bool isNull)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var connectionName = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddSqlServerDbContext<DbContext>(connectionName);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(connectionName), exception.ParamName);
+    }
+
+    [Fact]
+    public void EnrichSqlServerDbContextShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+
+        var action = () => builder.EnrichSqlServerDbContext<DbContext>();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+}


### PR DESCRIPTION
Initial issues [#2649](https://github.com/dotnet/aspire/issues/2649)
Issues [#5047](https://github.com/dotnet/aspire/issues/5047)
[message](https://github.com/dotnet/aspire/issues/5047#issuecomment-2278838761)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No

Added public API test coverage for:
- [x] Aspire.Microsoft.EentityFrameworkCore.SqlServer

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5402)