### PR TITLE
update validate-arguments-of-public-methods#aspire-my-sql-connector

### DIFF
--- a/src/Components/Aspire.MySqlConnector/AspireMySqlConnectorExtensions.cs
+++ b/src/Components/Aspire.MySqlConnector/AspireMySqlConnectorExtensions.cs
@@ -50,10 +50,14 @@ public static class AspireMySqlConnectorExtensions
         AddMySqlDataSource(builder, configureSettings, connectionName: name, serviceKey: name);
     }
 
-    private static void AddMySqlDataSource(IHostApplicationBuilder builder,
-        Action<MySqlConnectorSettings>? configureSettings, string connectionName, object? serviceKey)
+    private static void AddMySqlDataSource(
+        IHostApplicationBuilder builder,
+        Action<MySqlConnectorSettings>? configureSettings,
+        string connectionName,
+        object? serviceKey)
     {
         ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(connectionName);
 
         MySqlConnectorSettings settings = new();
         var configSection = builder.Configuration.GetSection(DefaultConfigSectionName);

--- a/tests/Aspire.MySqlConnector.Tests/MySqlConnectorPublicApiTests.cs
+++ b/tests/Aspire.MySqlConnector.Tests/MySqlConnectorPublicApiTests.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Aspire.MySqlConnector.Tests;
+
+public class MySqlConnectorPublicApiTests
+{
+    [Fact]
+    public void AddMySqlDataSourceShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string connectionName = "mysql";
+
+        var action = () => builder.AddMySqlDataSource(connectionName);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddMySqlDataSourceShouldThrowWhenConnectionNameIsNullOrEmpty(bool isNull)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var connectionName = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddMySqlDataSource(connectionName);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(connectionName), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddKeyedMySqlDataSourceShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string name = "mysql";
+
+        var action = () => builder.AddKeyedMySqlDataSource(name);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddKeyedMySqlDataSourceShouldThrowWhenNameIsNullOrEmpty(bool isNull)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var name = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddKeyedMySqlDataSource(name);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(name), exception.ParamName);
+    }
+}


### PR DESCRIPTION
Initial issues [#2649](https://github.com/dotnet/aspire/issues/2649)
Issues [#5047](https://github.com/dotnet/aspire/issues/5047)
[message](https://github.com/dotnet/aspire/issues/5047#issuecomment-2278838761)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No

Added public API test coverage for:
- [x] Aspire.MySqlConnector

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5402)