### PR TITLE
update validate-arguments-of-public-methods#aspire-oracle-entity-framework-core

### DIFF
--- a/src/Components/Aspire.Oracle.EntityFrameworkCore/AspireOracleEFCoreExtensions.cs
+++ b/src/Components/Aspire.Oracle.EntityFrameworkCore/AspireOracleEFCoreExtensions.cs
@@ -42,6 +42,7 @@ public static class AspireOracleEFCoreExtensions
         Action<DbContextOptionsBuilder>? configureDbContextOptions = null) where TContext : DbContext
     {
         ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(connectionName);
 
         builder.EnsureDbContextNotRegistered<TContext>();
 

--- a/tests/Aspire.Oracle.EntityFrameworkCore.Tests/OracleEntityFrameworkCorePublicApiTests.cs
+++ b/tests/Aspire.Oracle.EntityFrameworkCore.Tests/OracleEntityFrameworkCorePublicApiTests.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Aspire.Oracle.EntityFrameworkCore.Tests;
+
+public class OracleEntityFrameworkCorePublicApiTests
+{
+    [Fact]
+    public void AddOracleDatabaseDbContextShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string connectionName = "oracledb";
+
+        var action = () => builder.AddOracleDatabaseDbContext<DbContext>(connectionName);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddOracleDatabaseDbContextShouldThrowWhenConnectionNameIsNullOrEmpty(bool isNull)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var connectionName = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddOracleDatabaseDbContext<DbContext>(connectionName);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(connectionName), exception.ParamName);
+    }
+
+    [Fact]
+    public void EnrichOracleDatabaseDbContextShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+
+        var action = () => builder.EnrichOracleDatabaseDbContext<DbContext>();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+}


### PR DESCRIPTION
Initial issues [#2649](https://github.com/dotnet/aspire/issues/2649)
Issues [#5047](https://github.com/dotnet/aspire/issues/5047)
[message](https://github.com/dotnet/aspire/issues/5047#issuecomment-2278838761)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No

Added public API test coverage for:
- [x] Aspire.Oracle.EntityFrameworkCore

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5402)