### PR TITLE
update validate-arguments-of-public-methods#aspire-pomelo-entity-framework-core-my-sql

### DIFF
--- a/src/Components/Aspire.Pomelo.EntityFrameworkCore.MySql/AspireEFMySqlExtensions.cs
+++ b/src/Components/Aspire.Pomelo.EntityFrameworkCore.MySql/AspireEFMySqlExtensions.cs
@@ -50,9 +50,11 @@ public static partial class AspireEFMySqlExtensions
         this IHostApplicationBuilder builder,
         string connectionName,
         Action<PomeloEntityFrameworkCoreMySqlSettings>? configureSettings = null,
-        Action<DbContextOptionsBuilder>? configureDbContextOptions = null) where TContext : DbContext
+        Action<DbContextOptionsBuilder>? configureDbContextOptions = null)
+        where TContext : DbContext
     {
         ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(connectionName);
 
         builder.EnsureDbContextNotRegistered<TContext>();
 
@@ -140,7 +142,8 @@ public static partial class AspireEFMySqlExtensions
     /// <exception cref="InvalidOperationException">Thrown when mandatory <see cref="DbContext"/> is not registered in DI.</exception>
     public static void EnrichMySqlDbContext<[DynamicallyAccessedMembers(RequiredByEF)] TContext>(
             this IHostApplicationBuilder builder,
-            Action<PomeloEntityFrameworkCoreMySqlSettings>? configureSettings = null) where TContext : DbContext
+            Action<PomeloEntityFrameworkCoreMySqlSettings>? configureSettings = null)
+        where TContext : DbContext
     {
         ArgumentNullException.ThrowIfNull(builder);
 

--- a/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/PomeloEntityFrameworkCoreMySqlPublicApiTests.cs
+++ b/tests/Aspire.Pomelo.EntityFrameworkCore.MySql.Tests/PomeloEntityFrameworkCoreMySqlPublicApiTests.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Aspire.Pomelo.EntityFrameworkCore.MySql.Tests;
+
+public class PomeloEntityFrameworkCoreMySqlPublicApiTests
+{
+    [Fact]
+    public void AddMySqlDbContextShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string connectionName = "mysql";
+
+        var action = () => builder.AddMySqlDbContext<DbContext>(connectionName);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddMySqlDbContextShouldThrowWhenConnectionNameIsNullOrEmpty(bool isNull)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var connectionName = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddMySqlDbContext<DbContext>(connectionName);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(connectionName), exception.ParamName);
+    }
+
+    [Fact]
+    public void EnrichMySqlDbContextShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+
+        var action = () => builder.EnrichMySqlDbContext<DbContext>();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+}


### PR DESCRIPTION
Initial issues [#2649](https://github.com/dotnet/aspire/issues/2649)
Issues [#5047](https://github.com/dotnet/aspire/issues/5047)
[message](https://github.com/dotnet/aspire/issues/5047#issuecomment-2278838761)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No

Added public API test coverage for:
- [x] Aspire.Pomelo.EntityFrameworkCore.MySql

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5402)