### PR TITLE
update validate-arguments-of-public-methods#aspire-stack-exchange-redis-output-caching

### DIFF
--- a/src/Components/Aspire.StackExchange.Redis.OutputCaching/AspireRedisOutputCacheExtensions.cs
+++ b/src/Components/Aspire.StackExchange.Redis.OutputCaching/AspireRedisOutputCacheExtensions.cs
@@ -26,8 +26,15 @@ public static class AspireRedisOutputCacheExtensions
     /// Also registers <see cref="IConnectionMultiplexer"/> as a singleton in the services provided by the <paramref name="builder"/>.
     /// Enables retries, corresponding health check, logging, and telemetry.
     /// </remarks>
-    public static void AddRedisOutputCache(this IHostApplicationBuilder builder, string connectionName, Action<StackExchangeRedisSettings>? configureSettings = null, Action<ConfigurationOptions>? configureOptions = null)
+    public static void AddRedisOutputCache(
+        this IHostApplicationBuilder builder,
+        string connectionName,
+        Action<StackExchangeRedisSettings>? configureSettings = null,
+        Action<ConfigurationOptions>? configureOptions = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(connectionName);
+
         builder.AddRedisClient(connectionName, configureSettings, configureOptions);
 
         builder.AddRedisOutputCacheCore((RedisOutputCacheOptions options, IServiceProvider sp) =>
@@ -49,8 +56,15 @@ public static class AspireRedisOutputCacheExtensions
     /// Also registers <see cref="IConnectionMultiplexer"/> as a singleton in the services provided by the <paramref name="builder"/>.
     /// Enables retries, corresponding health check, logging, and telemetry.
     /// </remarks>
-    public static void AddKeyedRedisOutputCache(this IHostApplicationBuilder builder, string name, Action<StackExchangeRedisSettings>? configureSettings = null, Action<ConfigurationOptions>? configureOptions = null)
+    public static void AddKeyedRedisOutputCache(
+        this IHostApplicationBuilder builder,
+        string name,
+        Action<StackExchangeRedisSettings>? configureSettings = null,
+        Action<ConfigurationOptions>? configureOptions = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
         builder.AddKeyedRedisClient(name, configureSettings, configureOptions);
 
         builder.AddRedisOutputCacheCore((RedisOutputCacheOptions options, IServiceProvider sp) =>

--- a/tests/Aspire.StackExchange.Redis.OutputCaching.Tests/StackExchangeRedisOutputCachingPublicApiTests.cs
+++ b/tests/Aspire.StackExchange.Redis.OutputCaching.Tests/StackExchangeRedisOutputCachingPublicApiTests.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Aspire.StackExchange.Redis.OutputCaching.Tests;
+
+public class StackExchangeRedisOutputCachingPublicApiTests
+{
+    [Fact]
+    public void AddRedisOutputCacheShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string connectionName = "redis";
+
+        var action = () => builder.AddRedisOutputCache(connectionName);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddRedisOutputCacheShouldThrowWhenConnectionNameIsNullOrEmpty(bool isNull)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var connectionName = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddRedisOutputCache(connectionName);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(connectionName), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddKeyedRedisOutputCacheShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string name = "redis";
+
+        var action = () => builder.AddKeyedRedisOutputCache(name);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddKeyedRedisOutputCacheShouldThrowWhenNameIsNullOrEmpty(bool isNull)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var name = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddKeyedRedisOutputCache(name);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(name), exception.ParamName);
+    }
+}


### PR DESCRIPTION
Initial issues [#2649](https://github.com/dotnet/aspire/issues/2649)
Issues [#5047](https://github.com/dotnet/aspire/issues/5047)
[message](https://github.com/dotnet/aspire/issues/5047#issuecomment-2278838761)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No

Added public API test coverage for:
- [x] Aspire.StackExchange.Redis.OutputCaching

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5402)