### PR TITLE
update validate-arguments-of-public-methods#aspire-stack-exchange-redis-distributed-caching

### DIFF
--- a/src/Components/Aspire.StackExchange.Redis.DistributedCaching/AspireRedisDistributedCacheExtensions.cs
+++ b/src/Components/Aspire.StackExchange.Redis.DistributedCaching/AspireRedisDistributedCacheExtensions.cs
@@ -27,8 +27,15 @@ public static class AspireRedisDistributedCacheExtensions
     /// Also registers <see cref="IConnectionMultiplexer"/> as a singleton in the services provided by the <paramref name="builder"/>.
     /// Enables retries, corresponding health check, logging, and telemetry.
     /// </remarks>
-    public static void AddRedisDistributedCache(this IHostApplicationBuilder builder, string connectionName, Action<StackExchangeRedisSettings>? configureSettings = null, Action<ConfigurationOptions>? configureOptions = null)
+    public static void AddRedisDistributedCache(
+        this IHostApplicationBuilder builder,
+        string connectionName,
+        Action<StackExchangeRedisSettings>? configureSettings = null,
+        Action<ConfigurationOptions>? configureOptions = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(connectionName);
+
         builder.AddRedisClient(connectionName, configureSettings, configureOptions);
 
         builder.AddRedisDistributedCacheCore((RedisCacheOptions options, IServiceProvider sp) =>
@@ -50,8 +57,15 @@ public static class AspireRedisDistributedCacheExtensions
     /// Also registers <see cref="IConnectionMultiplexer"/> as a singleton in the services provided by the <paramref name="builder"/>.
     /// Enables retries, corresponding health check, logging, and telemetry.
     /// </remarks>
-    public static void AddKeyedRedisDistributedCache(this IHostApplicationBuilder builder, string name, Action<StackExchangeRedisSettings>? configureSettings = null, Action<ConfigurationOptions>? configureOptions = null)
+    public static void AddKeyedRedisDistributedCache(
+        this IHostApplicationBuilder builder,
+        string name,
+        Action<StackExchangeRedisSettings>? configureSettings = null,
+        Action<ConfigurationOptions>? configureOptions = null)
     {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
         builder.AddKeyedRedisClient(name, configureSettings, configureOptions);
 
         builder.AddRedisDistributedCacheCore((RedisCacheOptions options, IServiceProvider sp) =>

--- a/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/StackExchangeRedisDistributedCachingPublicApiTests.cs
+++ b/tests/Aspire.StackExchange.Redis.DistributedCaching.Tests/StackExchangeRedisDistributedCachingPublicApiTests.cs
@@ -1,0 +1,66 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Aspire.StackExchange.Redis.DistributedCaching.Tests;
+
+public class StackExchangeRedisDistributedCachingPublicApiTests
+{
+    [Fact]
+    public void AddRedisDistributedCacheShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string connectionName = "redis";
+
+        var action = () => builder.AddRedisDistributedCache(connectionName);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddRedisDistributedCacheShouldThrowWhenConnectionNameIsNullOrEmpty(bool isNull)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var connectionName = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddRedisDistributedCache(connectionName);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(connectionName), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddKeyedRedisDistributedCacheShouldThrowWhenBuilderIsNull()
+    {
+        IHostApplicationBuilder builder = null!;
+        const string name = "redis";
+
+        var action = () => builder.AddKeyedRedisDistributedCache(name);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(builder), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AddKeyedRedisDistributedCacheShouldThrowWhenNameIsNullOrEmpty(bool isNull)
+    {
+        var builder = Host.CreateEmptyApplicationBuilder(null);
+        var name = isNull ? null! : string.Empty;
+
+        var action = () => builder.AddKeyedRedisDistributedCache(name);
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(name), exception.ParamName);
+    }
+}


### PR DESCRIPTION
Initial issues [#2649](https://github.com/dotnet/aspire/issues/2649)
Issues [#5047](https://github.com/dotnet/aspire/issues/5047)
[message](https://github.com/dotnet/aspire/issues/5047#issuecomment-2278838761)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No

Added public API test coverage for:
- [x] Aspire.StackExchange.Redis.DistributedCaching

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5402)