### PR TITLE
update validate-arguments-of-public-methods#aspire-extensions-service-discovery

### DIFF
--- a/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/ServiceEndpoint.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/ServiceEndpoint.cs
@@ -28,5 +28,10 @@ public abstract class ServiceEndpoint
     /// <param name="endPoint">The endpoint being represented.</param>
     /// <param name="features">Features of the endpoint.</param>
     /// <returns>A newly initialized <see cref="ServiceEndpoint"/>.</returns>
-    public static ServiceEndpoint Create(EndPoint endPoint, IFeatureCollection? features = null) => new ServiceEndpointImpl(endPoint, features);
+    public static ServiceEndpoint Create(EndPoint endPoint, IFeatureCollection? features = null)
+    {
+        ArgumentNullException.ThrowIfNull(endPoint);
+
+        return new ServiceEndpointImpl(endPoint, features);
+    }
 }

--- a/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/ServiceEndpointQuery.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/ServiceEndpointQuery.cs
@@ -35,6 +35,8 @@ public sealed class ServiceEndpointQuery
     /// <returns><see langword="true"/> if the value was successfully parsed; otherwise <see langword="false"/>.</returns>
     public static bool TryParse(string input, [NotNullWhen(true)] out ServiceEndpointQuery? query)
     {
+        ArgumentException.ThrowIfNullOrEmpty(input);
+
         bool hasScheme;
         if (!input.Contains("://", StringComparison.InvariantCulture)
             && Uri.TryCreate($"fakescheme://{input}", default, out var uri))

--- a/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/ServiceEndpointSource.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery.Abstractions/ServiceEndpointSource.cs
@@ -25,6 +25,7 @@ public sealed class ServiceEndpointSource
     public ServiceEndpointSource(List<ServiceEndpoint>? endpoints, IChangeToken changeToken, IFeatureCollection features)
     {
         ArgumentNullException.ThrowIfNull(changeToken);
+        ArgumentNullException.ThrowIfNull(features);
 
         _endpoints = endpoints;
         Features = features;

--- a/src/Microsoft.Extensions.ServiceDiscovery/ServiceDiscoveryHttpClientBuilderExtensions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/ServiceDiscoveryHttpClientBuilderExtensions.cs
@@ -21,6 +21,8 @@ public static class ServiceDiscoveryHttpClientBuilderExtensions
     /// <returns>The builder.</returns>
     public static IHttpClientBuilder AddServiceDiscovery(this IHttpClientBuilder httpClientBuilder)
     {
+        ArgumentNullException.ThrowIfNull(httpClientBuilder);
+
         var services = httpClientBuilder.Services;
         services.AddServiceDiscoveryCore();
         httpClientBuilder.AddHttpMessageHandler(services =>

--- a/src/Microsoft.Extensions.ServiceDiscovery/ServiceDiscoveryServiceCollectionExtensions.cs
+++ b/src/Microsoft.Extensions.ServiceDiscovery/ServiceDiscoveryServiceCollectionExtensions.cs
@@ -24,11 +24,9 @@ public static class ServiceDiscoveryServiceCollectionExtensions
     /// <param name="services">The service collection.</param>
     /// <returns>The service collection.</returns>
     public static IServiceCollection AddServiceDiscovery(this IServiceCollection services)
-    {
-        return services.AddServiceDiscoveryCore()
+        => AddServiceDiscoveryCore(services)
             .AddConfigurationServiceEndpointProvider()
             .AddPassThroughServiceEndpointProvider();
-    }
 
     /// <summary>
     /// Adds the core service discovery services and configures defaults.
@@ -37,18 +35,16 @@ public static class ServiceDiscoveryServiceCollectionExtensions
     /// <param name="configureOptions">The delegate used to configure service discovery options.</param>
     /// <returns>The service collection.</returns>
     public static IServiceCollection AddServiceDiscovery(this IServiceCollection services, Action<ServiceDiscoveryOptions> configureOptions)
-    {
-        return services.AddServiceDiscoveryCore(configureOptions: configureOptions)
+        => AddServiceDiscoveryCore(services, configureOptions: configureOptions)
             .AddConfigurationServiceEndpointProvider()
             .AddPassThroughServiceEndpointProvider();
-    }
 
     /// <summary>
     /// Adds the core service discovery services.
     /// </summary>
     /// <param name="services">The service collection.</param>
     /// <returns>The service collection.</returns>
-    public static IServiceCollection AddServiceDiscoveryCore(this IServiceCollection services) => services.AddServiceDiscoveryCore(configureOptions: _ => { });
+    public static IServiceCollection AddServiceDiscoveryCore(this IServiceCollection services) => AddServiceDiscoveryCore(services, configureOptions: _ => { });
 
     /// <summary>
     /// Adds the core service discovery services.
@@ -58,6 +54,9 @@ public static class ServiceDiscoveryServiceCollectionExtensions
     /// <returns>The service collection.</returns>
     public static IServiceCollection AddServiceDiscoveryCore(this IServiceCollection services, Action<ServiceDiscoveryOptions> configureOptions)
     {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
         services.AddOptions();
         services.AddLogging();
         services.TryAddTransient<IValidateOptions<ServiceDiscoveryOptions>, ServiceDiscoveryOptionsValidator>();
@@ -80,9 +79,7 @@ public static class ServiceDiscoveryServiceCollectionExtensions
     /// <param name="services">The service collection.</param>
     /// <returns>The service collection.</returns>
     public static IServiceCollection AddConfigurationServiceEndpointProvider(this IServiceCollection services)
-    {
-        return services.AddConfigurationServiceEndpointProvider(configureOptions: _ => { });
-    }
+        => AddConfigurationServiceEndpointProvider(services, configureOptions: _ => { });
 
     /// <summary>
     /// Configures a service discovery endpoint provider which uses <see cref="IConfiguration"/> to resolve endpoints.
@@ -92,6 +89,9 @@ public static class ServiceDiscoveryServiceCollectionExtensions
     /// <returns>The service collection.</returns>
     public static IServiceCollection AddConfigurationServiceEndpointProvider(this IServiceCollection services, Action<ConfigurationServiceEndpointProviderOptions> configureOptions)
     {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
         services.AddServiceDiscoveryCore();
         services.AddSingleton<IServiceEndpointProviderFactory, ConfigurationServiceEndpointProviderFactory>();
         services.AddTransient<IValidateOptions<ConfigurationServiceEndpointProviderOptions>, ConfigurationServiceEndpointProviderOptionsValidator>();
@@ -110,6 +110,8 @@ public static class ServiceDiscoveryServiceCollectionExtensions
     /// <returns>The service collection.</returns>
     public static IServiceCollection AddPassThroughServiceEndpointProvider(this IServiceCollection services)
     {
+        ArgumentNullException.ThrowIfNull(services);
+
         services.AddServiceDiscoveryCore();
         services.AddSingleton<IServiceEndpointProviderFactory, PassThroughServiceEndpointProviderFactory>();
         return services;

--- a/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ExtensionsServicePublicApiTests.cs
+++ b/tests/Microsoft.Extensions.ServiceDiscovery.Tests/ExtensionsServicePublicApiTests.cs
@@ -1,0 +1,218 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Microsoft.Extensions.ServiceDiscovery.Tests;
+
+#pragma warning disable IDE0200
+
+public class ExtensionsServicePublicApiTests
+{
+    [Fact]
+    public void AddServiceDiscoveryShouldThrowWhenHttpClientBuilderIsNull()
+    {
+        IHttpClientBuilder httpClientBuilder = null!;
+
+        var action = () => httpClientBuilder.AddServiceDiscovery();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(httpClientBuilder), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddServiceDiscoveryShouldThrowWhenServicesIsNull()
+    {
+        IServiceCollection services = null!;
+
+        var action = () => services.AddServiceDiscovery();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(services), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddServiceDiscoveryWithConfigureOptionsShouldThrowWhenServicesIsNull()
+    {
+        IServiceCollection services = null!;
+        Action<ServiceDiscoveryOptions> configureOptions = (_) => { };
+
+        var action = () => services.AddServiceDiscovery(configureOptions);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(services), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddServiceDiscoveryWithConfigureOptionsShouldThrowWhenConfigureOptionsIsNull()
+    {
+        var services = new ServiceCollection();
+        Action<ServiceDiscoveryOptions> configureOptions = null!;
+
+        var action = () => services.AddServiceDiscovery(configureOptions);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(configureOptions), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddServiceDiscoveryCoreShouldThrowWhenServicesIsNull()
+    {
+        IServiceCollection services = null!;
+
+        var action = () => services.AddServiceDiscoveryCore();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(services), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddServiceDiscoveryCoreWithConfigureOptionsShouldThrowWhenServicesIsNull()
+    {
+        IServiceCollection services = null!;
+        Action<ServiceDiscoveryOptions> configureOptions = (_) => { };
+
+        var action = () => services.AddServiceDiscoveryCore(configureOptions);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(services), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddServiceDiscoveryCoreWithConfigureOptionsShouldThrowWhenConfigureOptionsIsNull()
+    {
+        var services = new ServiceCollection();
+        Action<ServiceDiscoveryOptions> configureOptions = null!;
+
+        var action = () => services.AddServiceDiscoveryCore(configureOptions);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(configureOptions), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddConfigurationServiceEndpointProviderShouldThrowWhenServicesIsNull()
+    {
+        IServiceCollection services = null!;
+
+        var action = () => services.AddConfigurationServiceEndpointProvider();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(services), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddConfigurationServiceEndpointProviderWithConfigureOptionsShouldThrowWhenServicesIsNull()
+    {
+        IServiceCollection services = null!;
+        Action<ConfigurationServiceEndpointProviderOptions> configureOptions = (_) => { };
+
+        var action = () => services.AddConfigurationServiceEndpointProvider(configureOptions);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(services), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddConfigurationServiceEndpointProviderWithConfigureOptionsShouldThrowWhenConfigureOptionsIsNull()
+    {
+        var services = new ServiceCollection();
+        Action<ConfigurationServiceEndpointProviderOptions> configureOptions = null!;
+
+        var action = () => services.AddConfigurationServiceEndpointProvider(configureOptions);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(configureOptions), exception.ParamName);
+    }
+
+    [Fact]
+    public void AddPassThroughServiceEndpointProviderShouldThrowWhenServicesIsNull()
+    {
+        IServiceCollection services = null!;
+
+        var action = () => services.AddPassThroughServiceEndpointProvider();
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(services), exception.ParamName);
+    }
+
+    [Fact]
+    public async Task GetEndpointsAsyncShouldThrowWhenServiceNameIsNull()
+    {
+        var serviceEndpointWatcherFactory = new ServiceEndpointWatcherFactory(
+            new List<IServiceEndpointProviderFactory>(),
+            new Logger<ServiceEndpointWatcher>(new NullLoggerFactory()),
+            Options.Options.Create(new ServiceDiscoveryOptions()),
+            TimeProvider.System);
+
+        var serviceEndpointResolver = new ServiceEndpointResolver(serviceEndpointWatcherFactory, TimeProvider.System);
+        string serviceName = null!;
+
+        var action = async () => await serviceEndpointResolver.GetEndpointsAsync(serviceName, CancellationToken.None);
+
+        var exception = await Assert.ThrowsAsync<ArgumentNullException>(action);
+        Assert.Equal(nameof(serviceName), exception.ParamName);
+    }
+
+    [Fact]
+    public void CreateShouldThrowWhenEndPointIsNull()
+    {
+        EndPoint endPoint = null!;
+
+        var action = () => ServiceEndpoint.Create(endPoint);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(endPoint), exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void TryParseShouldThrowWhenEndPointIsNullOrEmpty(bool isNull)
+    {
+        var input = isNull ? null! : string.Empty;
+
+        var action = () =>
+        {
+            _ = ServiceEndpointQuery.TryParse(input, out _);
+        };
+
+        var exception = isNull
+            ? Assert.Throws<ArgumentNullException>(action)
+            : Assert.Throws<ArgumentException>(action);
+        Assert.Equal(nameof(input), exception.ParamName);
+    }
+
+    [Fact]
+    public void CtorServiceEndpointSourceShouldThrowWhenChangeTokenIsNull()
+    {
+        IChangeToken changeToken = null!;
+        var features = new FeatureCollection();
+        List<ServiceEndpoint>? endpoints = null;
+
+        var action = () => new ServiceEndpointSource(endpoints, changeToken, features);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(changeToken), exception.ParamName);
+    }
+
+    [Fact]
+    public void CtorServiceEndpointSourceShouldThrowWhenFeaturesIsNull()
+    {
+        var changeToken = NullChangeToken.Singleton;
+        IFeatureCollection features = null!;
+        List<ServiceEndpoint>? endpoints = null;
+
+        var action = () => new ServiceEndpointSource(endpoints, changeToken, features);
+
+        var exception = Assert.Throws<ArgumentNullException>(action);
+        Assert.Equal(nameof(features), exception.ParamName);
+    }
+}


### PR DESCRIPTION
Initial issues [#2649](https://github.com/dotnet/aspire/issues/2649)
Issues [#5047](https://github.com/dotnet/aspire/issues/5047)
[message](https://github.com/dotnet/aspire/issues/5047#issuecomment-2278838761)

## Checklist

- Is this feature complete?
  - [x] Yes. Ready to ship.
  - [ ] No. Follow-up changes expected.
- Are you including unit tests for the changes and scenario tests if relevant?
  - [x] Yes
  - [ ] No
- Did you add public API?
  - [ ] Yes
  - [x] No
- Does the change require an update in our Aspire docs?
  - [ ] Yes
  - [x] No

Added public API test coverage for:
- [x] Aspire.Extensions.ServiceDiscovery

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/aspire/pull/5402)